### PR TITLE
Allow dummy event in uiDraggable dragend handler

### DIFF
--- a/draganddrop.js
+++ b/draganddrop.js
@@ -39,7 +39,7 @@ angular.module("ngDragDrop",[])
                 element.bind("dragend", function (e) {
                     var sendChannel = attrs.dragChannel || "defaultchannel";
                     $rootScope.$broadcast("ANGULAR_DRAG_END", sendChannel);
-                    if (e.dataTransfer.dropEffect !== "none") {
+                    if (e.dataTransfer && e.dataTransfer.dropEffect !== "none") {
                         if (attrs.onDropSuccess) {
                             var fn = $parse(attrs.onDropSuccess);
                             scope.$apply(function () {


### PR DESCRIPTION
When using triggerHandler on an angular.js element, a dummy event is passed to the element. So for example calling

```
element.triggerHandler("dragend")
```

would cause a javascript exception, since `e` is undefined.

Calling `triggerHandler` is useful for example when the element being dragged is removed from the DOM before it receives the "dragend" event. In this case the "dragend" handler has to be called manually before removing the element.
