### PR TITLE
Add custom drag image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 #Angular-DragDrop
 
-folked from [ganarajpr/angular-dragdrop](https://github.com/ganarajpr/angular-dragdrop), add the support of custom drag image, all credits go to ganarajpr.
-
 Angular-DragDrop is a native HTML5 Drag and Drop directive written in pure Angular with no dependency on Jquery. 
 
 This is based on the work done by Jason Turim. While this [blog post](http://jasonturim.wordpress.com/2013/09/01/angularjs-drag-and-drop/) was the inspiration for creating a native Drag and Drop solution, the intention was to create something that was more generic. 


### PR DESCRIPTION
You can set custom drag images with "drag-image" attribution. drag-image will accept a function, with returns an object with three properties, image, xOffset, and yOffset, which are accepted by event.dataTransfer.setDragImage. For more details, please see [Drag Operations](https://developer.mozilla.org/en-US/docs/DragDrop/Drag_Operations#dragfeedback).
