### PR TITLE
workaround for dragend not firing on elements removed from dom

### DIFF
--- a/draganddrop.js
+++ b/draganddrop.js
@@ -74,6 +74,13 @@ angular.module("ngDragDrop",[])
                             scope.$apply(function () {
                                 fn(scope, {$event: e});
                             });
+                        } else {
+                            if (attrs.onDropFailure) {
+                                var fn = $parse(attrs.onDropFailure);
+                                scope.$apply(function () {
+                                    fn(scope, {$event: e});
+                                });
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Workaround for issue #37.

More information:
https://bugzilla.mozilla.org/show_bug.cgi?id=460801

Possible alternative described here:
https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Drag_operations#dragend
but would require a convention of never removing source element from dom inside onDrop.
