### PR TITLE
Fixed bug where dropChannel broadcast wrongly on hover.

### DIFF
--- a/draganddrop.js
+++ b/draganddrop.js
@@ -149,7 +149,7 @@ angular.module("ngDragDrop",[])
 
                 function onDragEnter(e) {
                     dragging++;
-                    $rootScope.$broadcast("ANGULAR_HOVER", dropChannel);
+                    $rootScope.$broadcast("ANGULAR_HOVER", dragChannel);
                     element.addClass(dragHoverClass);
                 }
 


### PR DESCRIPTION
- When unit testing the code I noticed that when setting
  dropChannel to '*' there would be situations where
  the regex compile in isDragChannelAccepted() would
  fail.  The onDragEnter() handler is broadcasting the
  dropChannel, and the handler for the ANGULAR_HOVER
  event is receiving it and passing it to
  isDragChannelAccepted() as the drag channel.  Changed
  so that onDragEnter() sends the drag channel instead.
