### PR TITLE
Preventing native DnD

### DIFF
--- a/draganddrop.js
+++ b/draganddrop.js
@@ -187,14 +187,29 @@ angular.module("ngDragDrop",[])
                     return channelMatchPattern.test("," + dropChannel + ",");
                 }
 
-                var deregisterDragStart = $rootScope.$on("ANGULAR_DRAG_START", function (event, channel) {
+                function preventNativeDnD(e) {
+                    if (e.preventDefault) {
+                        e.preventDefault();
+                    }
+                    if (e.stopPropagation) {
+                        e.stopPropagation();
+                    }
+                    e.dataTransfer.dropEffect = "none";
+                    return false;
+                }
+
+			var deregisterDragStart = $rootScope.$on("ANGULAR_DRAG_START", function (event, channel) {
                     dragChannel = channel;
                     if (isDragChannelAccepted(channel, dropChannel)) {
                         if (attr.dropValidate) {
                             var validateFn = $parse(attr.dropValidate);
                             var valid = validateFn(scope, {$data: currentData.data, $channel: currentData.channel});
                             if (!valid) {
-                                return;
+                                element.bind("dragover", preventNativeDnD);
+                                element.bind("dragenter", preventNativeDnD);
+                                element.bind("dragleave", preventNativeDnD);
+                                element.bind("drop", preventNativeDnD);
+								return;
                             }
                         }
 
@@ -205,6 +220,12 @@ angular.module("ngDragDrop",[])
                         element.bind("drop", onDrop);
                         element.addClass(dragEnterClass);
                     }
+					else {
+					    element.bind("dragover", preventNativeDnD);
+					    element.bind("dragenter", preventNativeDnD);
+					    element.bind("dragleave", preventNativeDnD);
+					    element.bind("drop", preventNativeDnD);
+					}
 
                 });
 
@@ -222,6 +243,11 @@ angular.module("ngDragDrop",[])
                         element.removeClass(dragHoverClass);
                         element.removeClass(dragEnterClass);
                     }
+					
+					element.unbind("dragover", preventNativeDnD);
+					element.unbind("dragenter", preventNativeDnD);
+					element.unbind("dragleave", preventNativeDnD);
+					element.unbind("drop", preventNativeDnD);
                 });
 
 


### PR DESCRIPTION
When using the ui-on-drop directive on an input field and the drop channel does not match, it is still possible to drop on it. The browser still accepts the drop and puts the JSON string in the field. 

I've added some logic to prevent DnD when the drop channel does not match or when the validate function returns false.

Here is a plunker to show the problem: http://plnkr.co/edit/AI4f95Lxxsh3MkDzz9H5?p=preview
Here is the plunker with my fix: http://plnkr.co/edit/lHlh6H20wnkSRAhLLQ3j?p=preview

Cheers,
Dan
