### PR TITLE
Fixes #56 - Unexpected token on Chrome under Linux

### DIFF
--- a/draganddrop.js
+++ b/draganddrop.js
@@ -116,7 +116,7 @@ angular.module("ngDragDrop",[])
                             });
                         }
 
-                        e.dataTransfer.setData("Text", sendData);
+                        e.dataTransfer.setData("dataToSend", sendData);
                         currentData = angular.fromJson(sendData);
                         e.dataTransfer.effectAllowed = "copyMove";
                         $rootScope.$broadcast("ANGULAR_DRAG_START", sendChannel);
@@ -173,7 +173,7 @@ angular.module("ngDragDrop",[])
                         e.stopPropagation(); // Necessary. Allows us to drop.
                     }
 
-                    var sendData = e.dataTransfer.getData("Text");
+                    var sendData = e.dataTransfer.getData("dataToSend");
                     sendData = angular.fromJson(sendData);
 
                     var fn = $parse(attr.uiOnDrop);


### PR DESCRIPTION
Fixes #56. 
Renames `"Text"` field into `"dataToSend"` as `"Text"` seems to already be used internally by Chrome
