### PR TITLE
Prevent Event Bubbling On Drag Hover

### DIFF
--- a/draganddrop.js
+++ b/draganddrop.js
@@ -153,14 +153,30 @@ angular.module("ang-drag-drop",[])
                 }
 
                 function onDragLeave(e) {
-                  dragging--;
+		  if (e.preventDefault) {
+			e.preventDefault();
+		  }
+		    
+		  if (e.stopPropagation) {
+			e.stopPropagation();
+		  }
+		  dragging--;
+
                   if (dragging == 0) {
                     element.removeClass(dragHoverClass);
                   }
                 }
 
-                function onDragEnter(e) {
-                    dragging++;
+                function onDragEnter(e) {                    
+		    if (e.preventDefault) {
+                        e.preventDefault();
+                    }
+
+                    if (e.stopPropagation) {
+                        e.stopPropagation();
+                    }
+		    dragging++;
+
                     $rootScope.$broadcast("ANGULAR_HOVER", dragChannel);
                     element.addClass(dragHoverClass);
                 }


### PR DESCRIPTION
Came across the use case where I had nested drop zones, but wanted _only_ the element being hovered over on drag to trigger a class change. Before this, if the drop zones were nested, it would only change the outermost parent, but with this it should just make change the most specific child.
