### PR TITLE
Need for sending custom data on dragOver, dragLeave and dragEnter events

### DIFF
--- a/draganddrop.js
+++ b/draganddrop.js
@@ -150,6 +150,11 @@ angular.module("ang-drag-drop",[])
                         e.stopPropagation();
                     }
 
+                    var fn = $parse(attr.uiOnDragOver);
+                    scope.$apply(function () {
+                        fn(scope, {$event: e, $channel: dropChannel});
+                    });
+
                     e.dataTransfer.dropEffect = e.shiftKey ? 'copy' : 'move';
                     return false;
                 }
@@ -170,6 +175,11 @@ angular.module("ang-drag-drop",[])
                         });
                         element.removeClass(dragHoverClass);
                     }
+
+                    var fn = $parse(attr.uiOnDragLeave);
+                    scope.$apply(function () {
+                        fn(scope, {$event: e, $channel: dropChannel});
+                    });
                 }
 
                 function onDragEnter(e) {
@@ -181,6 +191,11 @@ angular.module("ang-drag-drop",[])
                         e.stopPropagation();
                     }
                     dragging++;
+
+                    var fn = $parse(attr.uiOnDragEnter);
+                    scope.$apply(function () {
+                        fn(scope, {$event: e, $channel: dropChannel});
+                    });
 
                     $rootScope.$broadcast("ANGULAR_HOVER", dragChannel);
                     scope.$apply(function () {


### PR DESCRIPTION
Adds options for using callback functions on dragOver, dragLeave and dragEnter events - similar to ui-on-drop and on-drop-success callbacks. This gives the possibilty of using onDrag(Over/Leave/Enter)Handler and passing additional paramters to the handler (not possible when using ANGULAR_HOVER event). This is very helpful when building a sortable list of elements that shows preview of final order while still dragging.

Further more adjusted parameter of ANGULAR_DRAG_START event broadcast from JSON string to dragData object (feels a bit cleaner ;)

Hope you like! If you have questions, get in touch.

Cheers
Henry
