### PR TITLE
Fix custom drag events ordering and add $channel parameter

### DIFF
--- a/draganddrop.js
+++ b/draganddrop.js
@@ -171,7 +171,7 @@ angular.module("ang-drag-drop",[])
 
                     if (dragging == 0) {
                         scope.$evalAsync(function () {
-                            customDragEnterEvent(scope, {$event: e});
+                            customDragLeaveEvent(scope, {$event: e, $channel: dropChannel});
                         });
                         element.removeClass(dragHoverClass);
                     }
@@ -190,6 +190,13 @@ angular.module("ang-drag-drop",[])
                     if (e.stopPropagation) {
                         e.stopPropagation();
                     }
+
+                    if (dragging === 0) {
+                        scope.$evalAsync(function () {
+                            customDragEnterEvent(scope, {$event: e, $channel: dropChannel});
+                        });
+                        element.addClass(dragHoverClass);
+                    }
                     dragging++;
 
                     var fn = $parse(attr.uiOnDragEnter);
@@ -198,10 +205,6 @@ angular.module("ang-drag-drop",[])
                     });
 
                     $rootScope.$broadcast("ANGULAR_HOVER", dragChannel);
-                    scope.$evalAsync(function () {
-                        customDragLeaveEvent(scope, {$event: e});
-                    });
-                    element.addClass(dragHoverClass);
                 }
 
                 function onDrop(e) {


### PR DESCRIPTION
Oops :)

WORK IN PROGRESS, please read questions there :

Is there anybody using those events ? Are they really usefull, as there is `uiOnDragEnter` and `uiOnDragLeave` ?

If they are usefull, should the `onDragEnter` event (without `ui`) be fired on each `dragEnter`, or only when `dragging === 0` ?