### PR TITLE
fix(ang-drag-drop) Fix for IE

### DIFF
--- a/draganddrop.js
+++ b/draganddrop.js
@@ -9,10 +9,11 @@
 (function(angular){
 
 function isDnDsSupported(){
-    return 'draggable' in document.createElement("span");
+    return 'ondrag' in document.createElement("a");
 }
 
 if(!isDnDsSupported()){
+    angular.module("ang-drag-drop", []);
     return;
 }
 


### PR DESCRIPTION
Change the DnD support test and always return a module in order to prevent angular from crashing in IE9-
