### PR TITLE
fix for copy (ctrl+drag on Linux/Windows, option+drag on Mac)

### DIFF
--- a/draganddrop.js
+++ b/draganddrop.js
@@ -155,7 +155,6 @@ angular.module("ang-drag-drop",[])
                         fn(scope, {$event: e, $channel: dropChannel});
                     });
 
-                    e.dataTransfer.dropEffect = e.shiftKey ? 'copy' : 'move';
                     return false;
                 }
 
@@ -214,6 +213,16 @@ angular.module("ang-drag-drop",[])
 
                     var sendData = e.dataTransfer.getData("dataToSend");
                     sendData = angular.fromJson(sendData);
+
+                    // Chrome doesn't set dropEffect, so we have to work it out ourselves
+                    if (e.dataTransfer.dropEffect === 'none') {
+                      if (e.dataTransfer.effectAllowed === 'copy' || 
+                          e.dataTransfer.effectAllowed === 'move') {
+                        e.dataTransfer.dropEffect = e.dataTransfer.effectAllowed;
+                      } else if (e.dataTransfer.effectAllowed === 'copyMove') {
+                        e.dataTransfer.dropEffect = e.ctrlKey ? "copy" : "move";
+                      }
+                    }
 
                     var fn = $parse(attr.uiOnDrop);
                     scope.$evalAsync(function () {


### PR DESCRIPTION
There are two changes:

First, remove the setting of dropEffect in the dragover handler. According to MDN, one should only set dropEffect in this handler to prevent the drag from completing. Since the directive is hard-coded to allow copy & move, we never want to interrupt the drag.

Second, a patch to allow one to check if $event.dataTransfer.dropEffect is "move" or "copy" in the drop handler. Chrome doesn't set dropEffect, so one needs to manually check which modifier key is pressed. The correct key to test for "copy" is Ctrl. Shift is always "move".

Tests OK with Firefox & Chrome on Linux / Windows / Mac. My test Mac is still running Mountain Lion, so I don't have an up-to-date Safari to test with.