### PR TITLE
Replace dataToSend with text

### DIFF
--- a/draganddrop.js
+++ b/draganddrop.js
@@ -112,7 +112,7 @@ angular.module("ang-drag-drop",[])
 				            });
 			            }
 
-			            e.dataTransfer.setData("dataToSend", sendData);
+			            e.dataTransfer.setData("text", sendData);
 			            currentData = angular.fromJson(sendData);
 			            e.dataTransfer.effectAllowed = "copyMove";
 			            $rootScope.$broadcast("ANGULAR_DRAG_START", sendChannel, currentData.data);
@@ -214,7 +214,7 @@ angular.module("ang-drag-drop",[])
                         e.stopPropagation(); // Necessary. Allows us to drop.
                     }
 
-                    var sendData = e.dataTransfer.getData("dataToSend");
+                    var sendData = e.dataTransfer.getData("text");
                     sendData = angular.fromJson(sendData);
 
                     // Chrome doesn't set dropEffect, so we have to work it out ourselves


### PR DESCRIPTION
I'm experiencing some issues with IE 11.
According to this : http://stackoverflow.com/questions/26213011/html5-dragdrop-issue-in-internet-explorer-datatransfer-property-access-not-pos only setData("text", sendData) works. Tested and confirmed.