### PR TITLE
Export module name so it works like other angular modules in npm

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./draganddrop');
+module.exports = 'ang-drag-drop';

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular-native-dragdrop",
   "version": "1.1.0",
   "description": "Angular HTML5 Drag and Drop directive written in pure with no dependency on JQuery.",
-  "main": "draganddrop.js",
+  "main": "index.js",
   "scripts": {
     "test": "gulp"
   },


### PR DESCRIPTION
This way the module can easily be used with things like browserify for bundling client-side code, see also  http://blog.npmjs.org/post/114584444410/using-angulars-new-improved-browserify-support

I'm not sure what impact replacing the entry point script has on projects depending on this, I *think* all should work as normal, but maybe you can be a better judge of that