### PR TITLE
Fix event undefined value

### DIFF
--- a/draganddrop.js
+++ b/draganddrop.js
@@ -7,7 +7,7 @@
 
     function determineEffectAllowed(e) {
         // Chrome doesn't set dropEffect, so we have to work it out ourselves
-        if (e.dataTransfer && e.dataTransfer.dropEffect === 'none') {
+        if (typeof e.dataTransfer !== 'undefined' && e.dataTransfer.dropEffect === 'none') {
             if (e.dataTransfer.effectAllowed === 'copy' ||
                 e.dataTransfer.effectAllowed === 'move') {
                 e.dataTransfer.dropEffect = e.dataTransfer.effectAllowed;


### PR DESCRIPTION
There is a bug where event value sometimes is undefined (I am using Chrome on Ubuntu). This simple solution solves it. Please merge it as soon as possible :)