### PR TITLE
Allow specifying the drag image as another element on the page.

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -123,6 +123,54 @@
                 </ul>
             </div>
         </div>
+
+        <hr>
+
+        <h3>Custom Drag Image</h3>
+
+        <p>You may specify a drag-image-element-id to use as the drag image. You can use the
+            <a href="http://www.kryogenix.org/code/browser/custom-drag-image.html" target="_blank">ghost image</a>
+            technique for the custom drag image.</p>
+
+        <hr>
+
+
+        <div class="row" ng-controller="MainCtrl">
+            <div class="col-xs-6">
+                <ul>
+                    <li ui-draggable="true" drag="man"
+                        drag-channel="customImage2"
+                        drop-validate="dropValidateHandler($drop, $event, $data)"
+                        drag-hover-class="on-drag-hover-custom"
+                        drag-image-element-id="getCustomDragElementId($index)"
+                        on-drop-success="dropSuccessHandler($event,$index,men)"
+                        ui-on-drop="onDrop($event,$data,men,$index)"
+                        drop-channel="customImage1"
+                        ng-repeat="man in men track by $index">
+                        {{man}}
+                    </li>
+                </ul>
+            </div>
+            <div class="col-xs-6">
+                <ul>
+                    <li ui-draggable="true" drag="woman"
+                        drag-channel="customImage1"
+                        drop-validate="dropValidateHandler($drop, $event, $data)"
+                        drag-hover-class="on-drag-hover-custom"
+                        drag-image-element-id="getCustomDragElementId($index)"
+                        ui-on-drop="onDrop($event,$data,women,$index)"
+                        drop-channel="customImage2"
+                        on-drop-success="dropSuccessHandler($event,$index,women)"
+                        ng-repeat="woman in women track by $index">
+                        {{woman}}
+                    </li>
+                </ul>
+            </div>
+        </div>
+
+        <div id="customDrag0" class="alert alert-info" style="max-width: 200px">Custom drag image #1</div>
+        <div id="customDrag1" class="alert alert-danger" style="position: absolute; top: 0; right: 0; z-index: -2; max-width: 200px">Custom drag image #2</div>
+        <div id="coverUp" style="position: absolute; top: 0; right: 0; z-index: -1; background-color: white; width: 200px; height: 60px"></div>
     </div>
   </body>
 

--- a/demo/js/app.js
+++ b/demo/js/app.js
@@ -43,4 +43,8 @@ angular.module('app', [
         }
     };
 
+    $scope.getCustomDragElementId = function (index) {
+        return 'customDrag' + (index % 2);
+    }
+
 });

--- a/docs/index.html
+++ b/docs/index.html
@@ -60,8 +60,13 @@
 
     <p>The class used to mark child elements of draggable object to be used as drag handle. Default class name is
         <code>drag-handle</code>.</p>
+    <hr>
+    <h4 class="text-info"><em>drag-image-element-id</em></h4>
+
+    <p>The <code>drag-image-element-id</code> attribute takes a function that returns the id of a custom drag image that
+        is another element on the page.</p>
     <div>
-        <strong>NOTE</strong>: If attribute is not present drag handle feature is not active.
+        <strong>NOTE</strong>: If attribute is not present the browser's default drag image will be used.
     </div>
     <hr>
     <h4 class="text-info"><em>on-drop-success</em></h4>
@@ -105,6 +110,7 @@
         <ANY ui-draggable="{expression}"
              drag="dragData"
              drag-handle-class="my-drag-handle"
+             drag-image-element-id="getCustomDrageImageElementId()"
              on-drop-success="onDropSuccessHandler($event)"
              on-drop-failure="onDropFailureHandler($event)"
              drag-channel="mydropchannel">...
@@ -142,6 +148,14 @@
             <td>Class name used to mark child elements of draggable object to be used as drag handle. <br/>If attribute
                 is not present drag handle feature is not used. <br/>If attribute is present but have no value
                 <code>drag-handle</code> used as default.</td>
+        </tr>
+        <tr>
+            <td>drag-image-element-id</td>
+            <td><label class="text-muted">function</label></td>
+            <td>Function which returns the id of another element on the page to use as drag image. <br/>If attribute
+                is not present the browser's default drag image is used. You can use the
+                <a href="http://www.kryogenix.org/code/browser/custom-drag-image.html" target="_blank">ghost image</a>
+                technique for creating custom drag image that is not visible to the user.</td>
         </tr>
         <tr>
             <td>on-drop-success</td>

--- a/docs/index.html
+++ b/docs/index.html
@@ -113,7 +113,7 @@
         <ANY ui-draggable="{expression}"
              drag="dragData"
              drag-handle-class="my-drag-handle"
-             drag-image-element-id="getCustomDrageImageElementId()"
+             drag-image-element-id="getCustomDragImageElementId()"
              on-drop-success="onDropSuccessHandler($event)"
              on-drop-failure="onDropFailureHandler($event)"
              drag-channel="mydropchannel">...

--- a/docs/index.html
+++ b/docs/index.html
@@ -60,6 +60,9 @@
 
     <p>The class used to mark child elements of draggable object to be used as drag handle. Default class name is
         <code>drag-handle</code>.</p>
+    <div>
+        <strong>NOTE</strong>: If attribute is not present drag handle feature is not active.
+    </div>
     <hr>
     <h4 class="text-info"><em>drag-image-element-id</em></h4>
 

--- a/draganddrop.js
+++ b/draganddrop.js
@@ -87,6 +87,33 @@
                 element.removeClass(draggingClass);
             }
 
+            function setDragElement(e, dragImageElementId) {
+                var dragImageElementFn;
+
+                if (!(e && e.dataTransfer && e.dataTransfer.setDragImage)) {
+                    return;
+                }
+
+                dragImageElementFn = $parse(dragImageElementId);
+
+                scope.$apply(function() {
+                    var elementId = dragImageElementFn(scope, {$event: e}),
+                        dragElement;
+
+                    if (!(elementId && angular.isString(elementId))) {
+                        return;
+                    }
+
+                    dragElement = document.getElementById(elementId);
+
+                    if (!dragElement) {
+                        return;
+                    }
+
+                    e.dataTransfer.setDragImage(dragElement, 0, 0);
+                });
+            }
+
             function dragstartHandler(e) {
                 var isDragAllowed = !isDragHandleUsed || dragTarget.classList.contains(dragHandleClass);
 
@@ -121,6 +148,8 @@
                                 }
                             }
                         });
+                    } else if (attrs.dragImageElementId) {
+                        setDragElement(e, attrs.dragImageElementId);
                     }
 
                     var transferDataObject = {data: dragData, channel: sendChannel};


### PR DESCRIPTION
This feature allows specifying the element id of another element on the page to use as the drag image. It adds support for a drag-element-image-id attribute, which is evaluated as a function that should return the id of an element on the page. 

This allows using the ghost image technique for generating custom drag images seen here:
http://www.kryogenix.org/code/browser/custom-drag-image.html

or an other custom drag image. My particular use case is generating a drag image for the selected rows in a ui-grid: 
http://ui-grid.info/